### PR TITLE
feat: add custom cluster and attributes for wbmsw4

### DIFF
--- a/src/devices/wirenboard.ts
+++ b/src/devices/wirenboard.ts
@@ -648,6 +648,19 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Wirenboard",
         description: "Wall-mounted multi sensor",
         extend: [
+            m.deviceAddCustomCluster("sprutDeviceBase", {
+                ID: 0,
+                manufacturerCode: 26214,
+                attributes: {
+                    DeviceVersion: { ID: 26113, type: Zcl.DataType.CHAR_STR},
+                    DeviceSignature: { ID: 26114, type: Zcl.DataType.CHAR_STR},
+                    DeviceBootVersion: { ID: 26115, type: Zcl.DataType.CHAR_STR},
+                    ComponentVersion: { ID: 26117, type: Zcl.DataType.CHAR_STR},
+                    ComponentSignature: { ID: 26118, type: Zcl.DataType.CHAR_STR},
+                },
+                commands: {},
+                commandsResponse: {},
+            }),
             m.deviceAddCustomCluster("sprutDevice", {
                 ID: 26112,
                 manufacturerCode: 26214,


### PR DESCRIPTION
Add new cluster and attributes for wbmsw4.
sprutDeviceBase:
- DeviceVersion,
- DeviceSignature,
- DeviceBootVersion,
- ComponentVersion,
- ComponentSignature.